### PR TITLE
Add beta/alpha FFT processing

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,4 +14,5 @@ board = m5stick-c
 framework = arduino
 monitor_speed = 115200           ; シリアルモニタのボーレート
 lib_deps     = m5stack/M5Unified ; 公式共通ライブラリ
+               kosme/arduinoFFT ; FFT ライブラリ
 upload_speed = 750000            ; 書き込みを少し高速化（任意）


### PR DESCRIPTION
## Summary
- integrate `arduinoFFT` library
- buffer raw EEG samples and compute beta/alpha ratio
- render live ratio graph on the display
- fix FFT type and method calls

## Testing
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_684a781468748330ad81bfd8505f5350